### PR TITLE
Optimize get() + dequeue()

### DIFF
--- a/Queue.php
+++ b/Queue.php
@@ -48,9 +48,10 @@ class Queue
     public function dequeue()
     {
         $array = unserialize(shmop_read($this->shm_id, 0, $this->shm_size));
-        array_pop($array);
+        $item = array_pop($array);
         $this->items = shmop_write($this->shm_id, serialize($array), 0);
         $this->shm_size = shmop_size($this->shm_id);
+        return $item;
     }
     
     public function items()
@@ -60,9 +61,7 @@ class Queue
     
     public function get()
     {
-        $array = unserialize(shmop_read($this->shm_id, 0, $this->shm_size));
-        $this->dequeue();
-        return end($array);
+        return $this->dequeue();
     }
     
     public function close()


### PR DESCRIPTION
Presently, calling get() calls dequeue(), which doesn't return anything, which means that get() first needs to get the value. This is wasteful. If dequeue() returned the item it removed, then get can simply return that. No double-execution. In fact, what is the point of get other than terminology?